### PR TITLE
Replaced `master` branch references to `main`

### DIFF
--- a/azure-pipelines/pulumi-dotnet.yml
+++ b/azure-pipelines/pulumi-dotnet.yml
@@ -2,16 +2,16 @@ trigger:
     batch: true
     branches:
       include:
-      - master
+      - main
     paths:
       include:
       - [[ .PathFilter ]]
-  
+
 pr:
   branches:
     include:
-    # Run PR builds that target master.
-    - master
+    # Run PR builds that target main.
+    - main
   paths:
     include:
     - [[ .PathFilter ]]
@@ -40,7 +40,7 @@ jobs:
       command: 'preview'
       stack: '$(pulumiStackName)'
       args: '--cwd $(pulumiWorkingDirectory)'
-  
+
   - task: Pulumi@1
     condition: or(eq(variables['Build.Reason'], 'IndividualCI'), eq(variables['Build.Reason'], 'BatchedCI'))
     inputs:
@@ -49,4 +49,3 @@ jobs:
       command: 'up'
       stack: '$(pulumiStackName)'
       args: '--yes --cwd $(pulumiWorkingDirectory)'
-  

--- a/azure-pipelines/pulumi-go.yml
+++ b/azure-pipelines/pulumi-go.yml
@@ -2,7 +2,7 @@ trigger:
   batch: true
   branches:
     include:
-    - master
+    - main
   paths:
     include:
     - [[ .PathFilter ]]
@@ -10,8 +10,8 @@ trigger:
 pr:
   branches:
     include:
-    # Run PR builds that target master.
-    - master
+    # Run PR builds that target main.
+    - main
   paths:
     include:
     - [[ .PathFilter ]]
@@ -38,7 +38,7 @@ jobs:
       command: 'preview'
       stack: '$(pulumiStackName)'
       args: '--cwd $(pulumiWorkingDirectory)'
-  
+
   - task: Pulumi@1
     condition: or(eq(variables['Build.Reason'], 'IndividualCI'), eq(variables['Build.Reason'], 'BatchedCI'))
     inputs:

--- a/azure-pipelines/pulumi-nodejs.yml
+++ b/azure-pipelines/pulumi-nodejs.yml
@@ -2,7 +2,7 @@ trigger:
   batch: true
   branches:
     include:
-    - master
+    - main
   paths:
     include:
     - [[ .PathFilter ]]
@@ -10,8 +10,8 @@ trigger:
 pr:
   branches:
     include:
-    # Run PR builds that target master.
-    - master
+    # Run PR builds that target main.
+    - main
   paths:
     include:
     - [[ .PathFilter ]]
@@ -39,7 +39,7 @@ jobs:
       command: 'preview'
       stack: '$(pulumiStackName)'
       args: '--cwd $(pulumiWorkingDirectory)'
-  
+
   - task: Pulumi@1
     condition: or(eq(variables['Build.Reason'], 'IndividualCI'), eq(variables['Build.Reason'], 'BatchedCI'))
     inputs:

--- a/azure-pipelines/pulumi-python.yml
+++ b/azure-pipelines/pulumi-python.yml
@@ -2,7 +2,7 @@ trigger:
   batch: true
   branches:
     include:
-    - master
+    - main
   paths:
     include:
     - [[ .PathFilter ]]
@@ -10,8 +10,8 @@ trigger:
 pr:
   branches:
     include:
-    # Run PR builds that target master.
-    - master
+    # Run PR builds that target main.
+    - main
   paths:
     include:
     - [[ .PathFilter ]]
@@ -53,7 +53,7 @@ jobs:
       command: 'preview'
       stack: '$(pulumiStackName)'
       args: '--cwd $(pulumiWorkingDirectory)'
-  
+
   - task: Pulumi@1
     condition: or(eq(variables['Build.Reason'], 'IndividualCI'), eq(variables['Build.Reason'], 'BatchedCI'))
     inputs:

--- a/bitbucket-pipelines/pulumi-dotnet.yml
+++ b/bitbucket-pipelines/pulumi-dotnet.yml
@@ -17,9 +17,9 @@ pipelines:
           script:
             - *vars
             - pulumi preview --cwd ${PULUMI_WORKING_DIRECTORY} -s ${PULUMI_STACK_NAME}
-  
+
   branches:
-    master:
+    main:
       - step:
           name: Update infrastructure
           # Using the deployment keyword will ensure that only one pipeline is executing for

--- a/bitbucket-pipelines/pulumi-go.yml
+++ b/bitbucket-pipelines/pulumi-go.yml
@@ -17,9 +17,9 @@ pipelines:
           script:
             - *deps
             - pulumi preview --cwd ${PULUMI_WORKING_DIRECTORY} -s ${PULUMI_STACK_NAME}
-  
+
   branches:
-    master:
+    main:
       - step:
           name: Update infrastructure
           # Using the deployment keyword will ensure that only one pipeline is executing for

--- a/bitbucket-pipelines/pulumi-nodejs.yml
+++ b/bitbucket-pipelines/pulumi-nodejs.yml
@@ -17,9 +17,9 @@ pipelines:
           script:
             - *deps
             - pulumi preview --cwd ${PULUMI_WORKING_DIRECTORY} -s ${PULUMI_STACK_NAME}
-  
+
   branches:
-    master:
+    main:
       - step:
           name: Update infrastructure
           # Using the deployment keyword will ensure that only one pipeline is executing for

--- a/bitbucket-pipelines/pulumi-python.yml
+++ b/bitbucket-pipelines/pulumi-python.yml
@@ -29,9 +29,9 @@ pipelines:
           script:
             - *deps
             - pulumi preview --cwd ${PULUMI_WORKING_DIRECTORY} -s ${PULUMI_STACK_NAME}
-  
+
   branches:
-    master:
+    main:
       - step:
           name: Update infrastructure
           # Using the deployment keyword will ensure that only one pipeline is executing for

--- a/github-actions/pulumi-dotnet.yml
+++ b/github-actions/pulumi-dotnet.yml
@@ -2,12 +2,12 @@ name: Preview or update Pulumi app [[ .PulumiStackName ]]
 on:
   push:
     branches:
-      - master
+      - main
     paths:
       - [[ .PathFilter ]]
   pull_request:
     branches:
-      - master
+      - main
     paths:
       - [[ .PathFilter ]]
 

--- a/github-actions/pulumi-go.yml
+++ b/github-actions/pulumi-go.yml
@@ -2,12 +2,12 @@ name: Preview or update Pulumi app [[ .PulumiStackName ]]
 on:
   push:
     branches:
-      - master
+      - main
     paths:
       - [[ .PathFilter ]]
   pull_request:
     branches:
-      - master
+      - main
     paths:
       - [[ .PathFilter ]]
 

--- a/github-actions/pulumi-nodejs.yml
+++ b/github-actions/pulumi-nodejs.yml
@@ -2,12 +2,12 @@ name: Preview or update Pulumi app [[ .PulumiStackName ]]
 on:
   push:
     branches:
-      - master
+      - main
     paths:
       - [[ .PathFilter ]]
   pull_request:
     branches:
-      - master
+      - main
     paths:
       - [[ .PathFilter ]]
 

--- a/github-actions/pulumi-python.yml
+++ b/github-actions/pulumi-python.yml
@@ -2,12 +2,12 @@ name: Preview or update Pulumi app [[ .PulumiStackName ]]
 on:
   push:
     branches:
-      - master
+      - main
     paths:
       - [[ .PathFilter ]]
   pull_request:
     branches:
-      - master
+      - main
     paths:
       - [[ .PathFilter ]]
 

--- a/gitlab-ci-cd/pulumi-dotnet.yml
+++ b/gitlab-ci-cd/pulumi-dotnet.yml
@@ -32,4 +32,4 @@ update:
     - pulumi up --yes --cwd ${PULUMI_WORKING_DIRECTORY} -s ${PULUMI_STACK_NAME}
   only:
     refs:
-      - master
+      - main

--- a/gitlab-ci-cd/pulumi-go.yml
+++ b/gitlab-ci-cd/pulumi-go.yml
@@ -18,7 +18,7 @@ only:
 #   stage: pulumi
 #   script:
 #     - export
-  
+
 preview:
   stage: pulumi
   script:
@@ -32,4 +32,4 @@ update:
     - pulumi up --yes --cwd ${PULUMI_WORKING_DIRECTORY} -s ${PULUMI_STACK_NAME}
   only:
     refs:
-      - master
+      - main

--- a/gitlab-ci-cd/pulumi-nodejs.yml
+++ b/gitlab-ci-cd/pulumi-nodejs.yml
@@ -10,7 +10,7 @@ variables:
 only:
   changes:
     - [[ .PathFilter ]]
-  
+
 default:
   before_script:
     # Restore dependencies using yarn.
@@ -24,7 +24,7 @@ default:
   #   stage: pulumi
   #   script:
   #     - export
-  
+
 preview:
   stage: pulumi
   script:
@@ -38,4 +38,4 @@ update:
     - pulumi up --yes --cwd ${PULUMI_WORKING_DIRECTORY} -s ${PULUMI_STACK_NAME}
   only:
     refs:
-      - master
+      - main

--- a/gitlab-ci-cd/pulumi-python.yml
+++ b/gitlab-ci-cd/pulumi-python.yml
@@ -47,4 +47,4 @@ update:
     - pulumi up --yes --cwd ${PULUMI_WORKING_DIRECTORY} -s ${PULUMI_STACK_NAME}
   only:
     refs:
-      - master
+      - main


### PR DESCRIPTION
By default on a new git project the "main" branch is now named `main`.

These Pulumi Templates are often used on new projects using the newer default branch name.