### PR TITLE
[gitlab] fix ci/cd template

### DIFF
--- a/gitlab-ci-cd/pulumi-go.yml
+++ b/gitlab-ci-cd/pulumi-go.yml
@@ -7,10 +7,6 @@ variables:
   PULUMI_STACK_NAME: [[ .PulumiStackName ]]
   PULUMI_WORKING_DIRECTORY: [[ .WorkingDirectory ]]
 
-only:
-  changes:
-    - [[ .PathFilter ]]
-
 # Having problems with environment variables?
 # Uncomment the following job to see all env vars
 # exported in your GitLab Runner.
@@ -18,6 +14,9 @@ only:
 #   stage: pulumi
 #   script:
 #     - export
+#  rules:
+#    - changes:
+#        - [[ .PathFilter ]]
   
 preview:
   stage: pulumi
@@ -25,6 +24,9 @@ preview:
     - pulumi preview --cwd ${PULUMI_WORKING_DIRECTORY} -s ${PULUMI_STACK_NAME}
   only:
     - merge_requests
+  rules:
+    - changes:
+        - [[ .PathFilter ]]
 
 update:
   stage: pulumi
@@ -33,3 +35,6 @@ update:
   only:
     refs:
       - master
+  rules:
+    - changes:
+        - [[ .PathFilter ]]


### PR DESCRIPTION
`only` / `except` haven't been supported since v15 of `gitlab-ci.yml`

https://archives.docs.gitlab.com/15.11/ee/ci/yaml/index.html#only--except

Their suggestion is to use rules that have to be applied to each job.